### PR TITLE
Make ChunkStories work on OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ The local maven repository on your computer (.m2 folder) now contains copies of 
  * `./gradlew launcher:createExe` builds the launcher executables (.exe and .jar as well)
  * `./gradlew buildAll` builds all of the above
 
+##### Make it work with OS X
+
+In order to launch ChunkStories on OS X (tested only on 10.11), you need to follow steps above, and use following command line arguments:
+
+```sh
+# At least 2GB of RAM
+java -XstartOnFirstThread -Djava.awt.headless=true -Xmx2G -jar client/build/libs/chunkstories.jar --backend=OPENGL --core=../chunkstories-core/res/
+```
+
 ### Links
 
  * To learn how to play the game and register an account, please visit http://chunkstories.xyz

--- a/client/src/main/java/xyz/chunkstories/graphics/GraphicsBackendsEnum.kt
+++ b/client/src/main/java/xyz/chunkstories/graphics/GraphicsBackendsEnum.kt
@@ -1,10 +1,13 @@
 package xyz.chunkstories.graphics
 
 import org.lwjgl.glfw.GLFW.*
+import org.lwjgl.opengl.GL11.*
 import org.lwjgl.glfw.GLFWVulkan
 import xyz.chunkstories.client.glfw.GLFWWindow
 import xyz.chunkstories.graphics.opengl.OpenglGraphicsBackend
 import xyz.chunkstories.graphics.vulkan.VulkanGraphicsBackend
+import xyz.chunkstories.util.OSHelper
+import xyz.chunkstories.util.SupportedOS
 
 enum class GraphicsBackendsEnum(val glfwInitHints: () -> Unit, val usable: () -> Boolean, val init: (GraphicsEngineImplementation, GLFWWindow) -> GLFWBasedGraphicsBackend) {
     VULKAN({
@@ -21,6 +24,9 @@ enum class GraphicsBackendsEnum(val glfwInitHints: () -> Unit, val usable: () ->
         glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3)
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3)
         glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE)
+        
+        if(OSHelper.os == SupportedOS.OSX)
+            glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE)
 
         if(OpenglGraphicsBackend.debugMode)
             glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE)

--- a/client/src/main/java/xyz/chunkstories/graphics/common/shaders/compiler/spirvcross/SpirvCrossHelper.kt
+++ b/client/src/main/java/xyz/chunkstories/graphics/common/shaders/compiler/spirvcross/SpirvCrossHelper.kt
@@ -19,7 +19,7 @@ object SpirvCrossHelper {
         val nativeLib = when (OSHelper.os) {
             SupportedOS.WINDOWS -> "/spirvcrossj.dll"
             SupportedOS.LINUX -> "/libspirvcrossj.so"
-            SupportedOS.OSX -> TODO()
+            SupportedOS.OSX -> "/libspirvcrossj.jnilib"
         }
 
         val libRes = javaClass.getResource(nativeLib)

--- a/client/src/main/java/xyz/chunkstories/graphics/opengl/OpenglGraphicsBackend.kt
+++ b/client/src/main/java/xyz/chunkstories/graphics/opengl/OpenglGraphicsBackend.kt
@@ -45,7 +45,7 @@ data class OpenglSupport(val dsaSupport: Boolean)
 
 class OpenglGraphicsBackend(graphicsEngine: GraphicsEngineImplementation, window: GLFWWindow) : GLFWBasedGraphicsBackend(graphicsEngine, window), VoxelTexturesSupport {
     private val capabilities: GLCapabilities
-    private val requiredExtensions = setOf("GL_ARB_debug_output", "GL_ARB_texture_storage", "GL_ARB_draw_buffers_blend")
+    private val requiredExtensions = setOf(/* "GL_ARB_debug_output", */ "GL_ARB_texture_storage", "GL_ARB_draw_buffers_blend")
     val openglSupport: OpenglSupport
 
     var renderGraph: OpenglRenderGraph
@@ -200,7 +200,7 @@ class OpenglGraphicsBackend(graphicsEngine: GraphicsEngineImplementation, window
     }
 
     companion object {
-        var debugMode = true
+        var debugMode = false
         val logger = LoggerFactory.getLogger("client.gfx_gl")
     }
 }

--- a/client/src/main/java/xyz/chunkstories/graphics/opengl/OpenglGraphicsBackend.kt
+++ b/client/src/main/java/xyz/chunkstories/graphics/opengl/OpenglGraphicsBackend.kt
@@ -45,7 +45,7 @@ data class OpenglSupport(val dsaSupport: Boolean)
 
 class OpenglGraphicsBackend(graphicsEngine: GraphicsEngineImplementation, window: GLFWWindow) : GLFWBasedGraphicsBackend(graphicsEngine, window), VoxelTexturesSupport {
     private val capabilities: GLCapabilities
-    private val requiredExtensions = setOf(/* "GL_ARB_debug_output", */ "GL_ARB_texture_storage", "GL_ARB_draw_buffers_blend")
+    private val requiredExtensions = setOf("GL_ARB_texture_storage", "GL_ARB_draw_buffers_blend")
     val openglSupport: OpenglSupport
 
     var renderGraph: OpenglRenderGraph
@@ -100,6 +100,10 @@ class OpenglGraphicsBackend(graphicsEngine: GraphicsEngineImplementation, window
 
         val renderer = glGetString(GL_RENDERER) ?: throw Exception("Can't identify device name (GL_RENDERER returned null)")
         logger.debug("OpenGL Renderer: $renderer")
+
+        if(!extensionsList.contains("GL_ARB_debug_output")) {
+            debugMode = false
+        }
 
         if(!extensionsList.containsAll(requiredExtensions)) {
             JOptionPane.showMessageDialog(null, """
@@ -200,7 +204,7 @@ class OpenglGraphicsBackend(graphicsEngine: GraphicsEngineImplementation, window
     }
 
     companion object {
-        var debugMode = false
+        var debugMode = true
         val logger = LoggerFactory.getLogger("client.gfx_gl")
     }
 }


### PR DESCRIPTION
Thanks to @Hugobros3's help, here are few changes that I was able to launch CS on OS X (10.11). However, since the lack of knowledge about how Kotlin works, I wasn't able to fully finish the task. I would suggest adding a command line argument, or detect manually via `OsHelper` to enable/disable OpenGL's debug mode and remove `GL_ARB_debug_output` extension from the required extension list in case of disabling it.