### PR TITLE
Closes #14. Use `VK10` image memory requirements function.

### DIFF
--- a/client/src/main/java/xyz/chunkstories/graphics/vulkan/textures/VulkanTexture.kt
+++ b/client/src/main/java/xyz/chunkstories/graphics/vulkan/textures/VulkanTexture.kt
@@ -2,6 +2,7 @@ package xyz.chunkstories.graphics.vulkan.textures
 
 import org.lwjgl.system.MemoryStack.*
 import org.lwjgl.vulkan.*
+import org.lwjgl.vulkan.KHRGetMemoryRequirements2.vkGetImageMemoryRequirements2KHR
 import org.lwjgl.vulkan.VK10.vkAllocateMemory
 import org.lwjgl.vulkan.VK11.*
 import org.slf4j.LoggerFactory
@@ -87,7 +88,7 @@ open class VulkanTexture(val backend: VulkanGraphicsBackend, final override val 
 
             memReq2.pNext(memDedicatedReq.address())
 
-            vkGetImageMemoryRequirements2(backend.logicalDevice.vkDevice, memReqInfo2, memReq2)
+            vkGetImageMemoryRequirements2KHR(backend.logicalDevice.vkDevice, memReqInfo2, memReq2)
             useDedicatedAllocation = memDedicatedReq.prefersDedicatedAllocation() || memDedicatedReq.requiresDedicatedAllocation() || true
             //println("result is $useDedicatedAllocation")
 


### PR DESCRIPTION
Using `vkGetImageMemoryRequirements2KHR` instead of `vkGetImageMemoryRequirements2`.